### PR TITLE
Trivial restructuring/fixes

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -47,6 +47,37 @@ WabiSabi can be instantiated to construct a variety of CoinJoin transaction stru
 
 \section{Preliminaries}
 
+Hereby we give an informal and high-level description of applied cryptographic primitives. In the following the security parameter is denoted as $\lambda$.
+
+\subsection{Commitment schemes}
+A commitment scheme allows a party to commit to a message without enabling them to change their mind about the committed message after publishing the commitment. On the other hand the commitment should not reveal anything about the committed message.
+
+\noindent$\mathsf{Commit}(m,r)\xrightarrow{}\mathcal{C}$. The $\mathsf{Commit}$ algorithm generates a commitment $\mathcal{C}$ to message $m$ using randomness $r$.
+
+\noindent$\mathsf{OpenCom}(\mathcal{C},m,r)\xrightarrow{}\{\mathit{True},\mathit{False}\}$: one can verify the correctness of the opening of a commitment by checking $\mathcal{C}\stackrel{?}{=}\mathsf{Commit}(m,r)$. If equality holds the algorithm outputs $\mathit{True}$, otherwise $\mathit{False}$.
+
+For ease of understanding the reader can assume in the following that the commitment scheme is instantiated as a Pedersen commitment.
+
+\subsection{MAC}
+A message authentication code (MAC) ensures the integrity of a message and consists of the following three probabilistic polynomial-time algorithms.
+
+\noindent$\mathsf{GenMACKey}(\lambda)\xrightarrow{}{\mathsf{sk}}$. a party generates a secret key $\mathsf{sk}$ for MAC generation and verification.
+
+\noindent$\mathsf{MAC}_{\mathsf{sk}}(m)\xrightarrow{}t$. one can generate a MAC $t$ on a message a $m$ by using their $\mathsf{sk}$.
+
+\noindent$\mathsf{VerifyMAC}_{\mathsf{sk}}(m,t)\xrightarrow{}\{\mathit{True},\mathit{False}\}$. The issuer of the MAC can verify a MAC $t$ given the message $m$ it was issued on.
+
+The reader might intuitively think of a MAC as the symmetric-key counterpart of digital signatures. They both have the same goals and similar security requirements, however a MAC is not publicly verifiable.
+
+\subsection{Zero-knowledge proofs of knowledge}
+A very high-level, and hence somewhat imprecise, description of zero-knowledge proofs is provided. This protocol involves a prover and a verifier. A prover wishes to prove that a relation $\mathcal{R}$ holds with respect to a secret input $w$, called witness, and public input $x$. Specifically, the prover wants to prove that $(x, w) \in \mathcal{R}$ without revealing anything about $w$.
+
+\noindent$\mathsf{Prove}(x,w,\mathcal{R})\xrightarrow{}\pi$. Given $x$ and the private witness $w$ the prover generates a proof $\pi$.
+
+\noindent$\mathsf{Verify}(x,\pi,\mathcal{R})\xrightarrow{}\{\mathit{True},\mathit{False}\}$. The verifier is given the proof $\pi$ and $x$ and decides whether the prover knows a secret $w$ such that $\mathcal{R}(x,w)=1$ holds.
+
+\section{Protocol Overview}
+
 \subsection{Terminology and notation}
 
 \begin{definition} \textbf{Credential}:
@@ -63,35 +94,6 @@ During credential presentation randomized versions of the attributes are present
 
 Finally, $k$ is a protocol level constant, denoting the number of credentials used in input and output registration requests, and $v_{\mathit{max}} = 2^{51}-1$ constrains the amount value ranges.\footnote{$\log_2(2099999997690000) \approx 50.9$}
 
-\subsection{High-level Algorithms}
-Hereby we give an informal and high-level description of applied cryptographic primitives. In the following the security parameter is denoted as $\lambda$.
-
-\subsubsection{Commitment schemes}
-A commitment scheme allows a party to commit to a message without enabling them to change their mind about the committed message after publishing the commitment. On the other hand the commitment should not reveal anything about the committed message.
-
-\noindent$\mathsf{Commit}(m,r)\xrightarrow{}\mathcal{C}$. The $\mathsf{Commit}$ algorithm generates a commitment $\mathcal{C}$ to message $m$ using randomness $r$.
-
-\noindent$\mathsf{OpenCom}(\mathcal{C},m,r)\xrightarrow{}\{\mathit{True},\mathit{False}\}$: one can verify the correctness of the opening of a commitment by checking $\mathcal{C}\stackrel{?}{=}\mathsf{Commit}(m,r)$. If equality holds the algorithm outputs $\mathit{True}$, otherwise $\mathit{False}$.
-
-For ease of understanding the reader can assume in the following that the commitment scheme is instantiated as a Pedersen commitment.
-
-\subsubsection{MAC}
-A message authentication code (MAC) ensures the integrity of a message and consists of the following three probabilistic polynomial-time algorithms.
-
-\noindent$\mathsf{GenMACKey}(\lambda)\xrightarrow{}{\mathsf{sk}}$. a party generates a secret key $\mathsf{sk}$ for MAC generation and verification.
-
-\noindent$\mathsf{MAC}_{\mathsf{sk}}(m)\xrightarrow{}t$. one can generate a MAC $t$ on a message a $m$ by using their $\mathsf{sk}$.
-
-\noindent$\mathsf{VerifyMAC}_{\mathsf{sk}}(m,t)\xrightarrow{}\{\mathit{True},\mathit{False}\}$. The issuer of the MAC can verify a MAC $t$ given the message $m$ it was issued on.
-
-The reader might intuitively think of a MAC as the symmetric-key counterpart of digital signatures. They both have the same goals and similar security requirements, however a MAC is not publicly verifiable.
-
-\subsubsection{Zero-knowledge proofs of knowledge}
-A very high-level, and hence somewhat imprecise, description of zero-knowledge proofs is provided. This protocol involves a prover and a verifier. A prover wishes to prove that a relation $\mathcal{R}$ holds with respect to a secret input $w$, called witness, and public input $x$. Specifically, the prover wants to prove that $(x, w) \in \mathcal{R}$ without revealing anything about $w$.
-
-\noindent$\mathsf{Prove}(x,w,\mathcal{R})\xrightarrow{}\pi$. Given $x$ and the private witness $w$ the prover generates a proof $\pi$.
-
-\noindent$\mathsf{Verify}(x,\pi,\mathcal{R})\xrightarrow{}\{\mathit{True},\mathit{False}\}$. The verifier is given the proof $\pi$ and $x$ and decides whether the prover knows a secret $w$ such that $\mathcal{R}(x,w)=1$ holds.
 
 \subsection{Registration}
 

--- a/main.tex
+++ b/main.tex
@@ -142,7 +142,7 @@ She submits these proofs, the randomized attributes, and the serial numbers. The
 
 \subsubsection{Unified Registration}
 
-For more flexibility in a dynamic setting, where a user may not yet know her desired output allocation during input registration, and to allow for small\footnote{Specifically, $2 \le k \le 7 \approx \log_2\left(\frac{1}{4} \cdot \frac{\mathtt{MAX\_STANDARD\_TX\_WEIGHT}}{838~\mathrm{WU}}\right)$, because although $k=1$ suffices for flexibility it limits parallelism, leaking privacy by temporal fingerprinting.} values of $k$, we can generalize input and output registration into a single unified protocol, which also supports reissuance.
+For more flexibility in a dynamic setting, where a user may not yet know her desired output allocation during input registration, and to allow for small\footnote{Specifically, $2 \le k \le 10 \approx \log_2\left(\frac{\mathtt{MAX\_STANDARD\_TX\_WEIGHT} - 58}{274 + 124}\right)$, because although $k=1$ suffices for flexibility it limits parallelism, leaking privacy by temporal fingerprinting.} values of $k$, we can generalize input and output registration into a single unified protocol, which also supports reissuance.
 
 In this case Alice or Bob (depending on the registration phase) submits $k$ valid credentials and $k$ credential requests, where the sums of the underlying amount commitments must be balanced.
 


### PR DESCRIPTION
- incorrect calculation in footnote
- moved terminology around and changed heading levels to correct document outline and improve document structure