### PR TITLE
Add missing exponents in iparams formula

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -403,7 +403,7 @@ To rule out tagging of individual users the coordinator must prove knowledge of 
 \pi_{i}^{\mathit{iparams}}=\operatorname{PK}\{ & (w, w^{\prime}, x_{0}, x_{1}, y_v, y_s): \\
 &C_{W}={G_{w}}^{w} {G_{w^{\prime}}}^{w^\prime} \land \\
 &I=\frac{G_{V}}{{G_{x_{0}}}^{x_0} {G_{x_1}}^{x_1} {G_{y_v}}^{y_v} {G_{y_s}}^{y_s}} \land \\
-&V_i={G_w}^{w}{U_i}^{x_{0}+x_{1}t_i} M_{v_i} M_{s_i}
+&V_i={G_w}^{w}{U_i}^{x_{0}+x_{1}t_i} {M_{v_i}}^{y_v} {M_{s_i}}^{y_s}
 \}
 \end{align*}
 


### PR DESCRIPTION
The statement in the proof of the MAC's validity with respect to the
issuer parameters' was incorrect, spceifying a wrong value for the V
point.

Co-authored-by: lontivero <lucasontivero@gmail.com>