### PR TITLE
Correct generator used in proof of zero amout

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -424,7 +424,7 @@ M_{a_i} = {G_h}^{r_i}{G_g}^{a_i}
 In credential bootstrap requests the range proofs can be replaced with simpler proofs of $a_i = 0$:
 \[
   \pi^{\mathit{null}}_i = \operatorname{PK}\left\{ \left( r_i\right) :
-    M_{a_i} = {G_{g}}^{r_i}
+    M_{a_i} = {G_{h}}^{r_i}
   \right\}
 \]
 


### PR DESCRIPTION
if `M_{a_i} = {G_{g}}^{a_i} {G_{h}}^{r_i}` we have to proof the `a_i = 0` then `M_{a_i} = {G_{h}}^{r_i}`